### PR TITLE
Add dark mode theme with toggle button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,18 +4,21 @@ import Hero from './components/Hero';
 import AIAdvances from './components/AIAdvances';
 import UseCases from './components/UseCases';
 import Footer from './components/Footer';
+import { ThemeProvider } from './contexts/ThemeContext';
 
 function App() {
   return (
-    <div className="min-h-screen bg-gradient-to-b from-white to-slalom-lightGray">
-      <Header />
-      <main>
-        <Hero />
-        <AIAdvances />
-        <UseCases />
-      </main>
-      <Footer />
-    </div>
+    <ThemeProvider>
+      <div className="min-h-screen bg-gradient-to-b from-white to-slalom-lightGray dark:from-slalom-navy dark:to-black transition-colors duration-200">
+        <Header />
+        <main>
+          <Hero />
+          <AIAdvances />
+          <UseCases />
+        </main>
+        <Footer />
+      </div>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,7 +4,7 @@ const Footer: React.FC = () => {
   const currentYear = new Date().getFullYear();
   
   return (
-    <footer className="bg-slalom-navy text-white">
+    <footer className="bg-slalom-navy text-white dark:bg-black transition-colors duration-200">
       <div className="section-container py-8">
         <div className="grid md:grid-cols-3 gap-8">
           <div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import SlalomLogo from '../assets/slalom-logo.svg';
+import { useTheme } from '../contexts/ThemeContext';
 
 const Header: React.FC = () => {
+  const { theme, toggleTheme } = useTheme();
+
   return (
-    <header className="bg-white shadow-sm sticky top-0 z-10">
+    <header className="bg-white dark:bg-slalom-navy shadow-sm sticky top-0 z-10 transition-colors duration-200">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-4">
           <div className="flex items-center">
@@ -17,16 +20,35 @@ const Header: React.FC = () => {
                 target.src = 'https://www.slalom.com/sites/default/files/2020-10/Slalom_Logo_RGB_Digital_Blue.png';
               }}
             />
-            <span className="ml-3 text-xl font-semibold text-slalom-navy">Slalom GenAI Showcase</span>
+            <span className="ml-3 text-xl font-semibold text-slalom-navy dark:text-white transition-colors duration-200">
+              Slalom GenAI Showcase
+            </span>
           </div>
-          <nav className="hidden md:flex space-x-8">
-            <a href="#advances" className="text-slalom-gray hover:text-slalom-blue transition-colors">
-              AI Advances
-            </a>
-            <a href="#use-cases" className="text-slalom-gray hover:text-slalom-blue transition-colors">
-              Use Cases
-            </a>
-          </nav>
+          <div className="flex items-center space-x-4">
+            <nav className="hidden md:flex space-x-8">
+              <a href="#advances" className="text-slalom-gray dark:text-slalom-lightGray hover:text-slalom-blue transition-colors">
+                AI Advances
+              </a>
+              <a href="#use-cases" className="text-slalom-gray dark:text-slalom-lightGray hover:text-slalom-blue transition-colors">
+                Use Cases
+              </a>
+            </nav>
+            <button 
+              onClick={toggleTheme} 
+              className="p-2 rounded-full hover:bg-slalom-lightGray dark:hover:bg-gray-700 transition-colors"
+              aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+            >
+              {theme === 'dark' ? (
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-yellow-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z" />
+                </svg>
+              ) : (
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6 text-slalom-navy" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z" />
+                </svg>
+              )}
+            </button>
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const Hero: React.FC = () => {
   return (
-    <section className="bg-gradient-to-r from-slalom-navy to-slalom-blue text-white">
+    <section className="bg-gradient-to-r from-slalom-navy to-slalom-blue text-white dark:from-black dark:to-slalom-navy transition-colors duration-200">
       <div className="section-container">
         <div className="grid md:grid-cols-2 gap-8 items-center">
           <div>
@@ -23,7 +23,7 @@ const Hero: React.FC = () => {
               </a>
               <a 
                 href="#use-cases" 
-                className="px-6 py-3 bg-white text-slalom-blue font-medium rounded-md text-center hover:bg-opacity-90 transition-colors"
+                className="px-6 py-3 bg-white dark:bg-slalom-teal text-slalom-blue dark:text-slalom-navy font-medium rounded-md text-center hover:bg-opacity-90 transition-colors"
               >
                 View Use Cases
               </a>
@@ -33,7 +33,7 @@ const Hero: React.FC = () => {
             <div className="relative">
               <div className="absolute -top-16 -right-16 w-64 h-64 bg-slalom-teal rounded-full opacity-20 blur-3xl"></div>
               <div className="absolute -bottom-8 -left-8 w-48 h-48 bg-white rounded-full opacity-10 blur-2xl"></div>
-              <div className="relative z-10 bg-white/10 backdrop-blur-sm p-6 rounded-lg border border-white/20">
+              <div className="relative z-10 bg-white/10 dark:bg-slalom-navy/30 backdrop-blur-sm p-6 rounded-lg border border-white/20 dark:border-white/10 transition-colors duration-200">
                 <div className="flex items-center mb-4">
                   <div className="w-3 h-3 bg-red-500 rounded-full mr-2"></div>
                   <div className="w-3 h-3 bg-yellow-500 rounded-full mr-2"></div>

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,63 @@
+import React, { createContext, useState, useContext, useEffect, ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  // Check for saved theme preference or prefer-color-scheme
+  const getInitialTheme = (): Theme => {
+    const savedTheme = localStorage.getItem('theme') as Theme;
+    
+    if (savedTheme === 'light' || savedTheme === 'dark') {
+      return savedTheme;
+    }
+    
+    // Check if user has dark mode enabled in their OS/browser settings
+    return window.matchMedia('(prefers-color-scheme: dark)').matches 
+      ? 'dark' 
+      : 'light';
+  };
+
+  const [theme, setTheme] = useState<Theme>('light'); // Default value before useEffect runs
+
+  // Initialize theme after component is mounted (to avoid SSR issues)
+  useEffect(() => {
+    setTheme(getInitialTheme());
+  }, []);
+
+  // Update HTML class and localStorage when theme changes
+  useEffect(() => {
+    const root = window.document.documentElement;
+    
+    root.classList.remove('light', 'dark');
+    root.classList.add(theme);
+    
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prevTheme => prevTheme === 'light' ? 'dark' : 'light');
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  
+  return context;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -22,18 +22,18 @@ code {
   }
   
   .heading-1 {
-    @apply text-4xl md:text-5xl font-bold text-slalom-navy;
+    @apply text-4xl md:text-5xl font-bold text-slalom-navy dark:text-white;
   }
   
   .heading-2 {
-    @apply text-3xl md:text-4xl font-bold text-slalom-navy;
+    @apply text-3xl md:text-4xl font-bold text-slalom-navy dark:text-white;
   }
   
   .heading-3 {
-    @apply text-2xl md:text-3xl font-semibold text-slalom-navy;
+    @apply text-2xl md:text-3xl font-semibold text-slalom-navy dark:text-white;
   }
   
   .card {
-    @apply bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow duration-300;
+    @apply bg-white dark:bg-slalom-navy dark:text-white rounded-lg shadow-md p-6 hover:shadow-lg transition-all duration-300;
   }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ module.exports = {
   content: [
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
+  darkMode: 'class', // Enable class-based dark mode
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
# Dark Mode Implementation

This PR adds a dark mode toggle feature to the site as requested in [issue #1](https://github.com/jdebo-slalom/jdebo-slalom.github.io/issues/1).

## Changes Made:

- Created a ThemeContext using React Context API to manage theme state across components
- Added dark mode configuration to Tailwind config
- Created a dark/light theme toggle button in the Header component 
- Updated component styles to support both light and dark themes
- Added theme persistence in localStorage
- Added support for system preference detection

## Preview:

The toggle button appears in the header and allows users to switch between light and dark themes. The site respects the user's system preference on first visit.

## Testing:

- Tested toggle functionality across components
- Verified theme persistence across page reloads
- Confirmed proper styling in both themes

Closes #1